### PR TITLE
Replacing config to provider-config in action workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Example Usage
         uses: projectdiscovery/notify-action@main
         with:
           data: output.txt
-          config: notify-config.yaml
+          provider-config: notify-config.yaml
 ```
 
 **Example workflow** - `.github/workflows/notify.yml`
@@ -44,7 +44,7 @@ jobs:
         uses: projectdiscovery/notify-action@main
         with:
           data: output.txt
-          config: notify-config.yaml
+          provider-config: notify-config.yaml
 ```
 
 
@@ -54,5 +54,5 @@ Available Inputs
 | Key      | Description                        | Required |
 |----------|------------------------------------|----------|
 | `data`   | Input file to send with notify     | false    |
-| `config` | Config file to use with notify     | false    |
+| `provider-config` | Config file to use with notify     | false    |
 | `flags`  | Additional notify CLI flags to use | false    |

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "Input file to send with notify"
     required: false
 
-  config:
+  provider-config:
     description: "Config file to use with notify"
     required: false
 
@@ -23,14 +23,13 @@ runs:
     - run: |
         [ ! -x /home/runner/go/bin/notify ] && go install -v github.com/projectdiscovery/notify/cmd/notify@latest
         [ ! -z ${{ inputs.data }} ] && echo "data=< ${{ inputs.data}}" >> $GITHUB_ENV
-        [ ! -z ${{ inputs.config }} ] && mkdir -p /home/runner/.config/notify/ && cp ${{ inputs.config }} /home/runner/.config/notify/notify.conf
+        [ ! -z ${{ inputs.provider-config }} ] && echo "provider-config=-provider-config ${{ inputs.provider-config}}" >> $GITHUB_ENV
         [ ! -z "${{ inputs.flags }}" ] && echo "flags=${{ inputs.flags }}" >> $GITHUB_ENV
         echo "/home/runner/go/bin/" >> $GITHUB_PATH
       shell: bash
-
     - run: |
         notify \
-          ${{ env.config }} \
+          ${{ env.provider-config }} \
           ${{ env.flags }} \
           ${{ env.data }}
       shell: bash


### PR DESCRIPTION
Initially when we use the default action from notify-action it was observed that the config flag was not working as intended after multiple trail and error I concluded that instead of using config we can replace it with provider-config to make the action workflow 

#### Error triggered using default/older action workflow 
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/87799917/170723713-3aa1f309-69fa-4d6f-8764-6b636ef371a6.png">

#### Workflow after applying the chnage
<img width="518" alt="image" src="https://user-images.githubusercontent.com/87799917/170724484-d0bc49a7-dc96-4b63-8a0f-ad67a73422d1.png">

